### PR TITLE
Make rediraffe_redirects default None

### DIFF
--- a/sphinxext/rediraffe.py
+++ b/sphinxext/rediraffe.py
@@ -400,7 +400,7 @@ class WriteRedirectsDiffBuilder(CheckRedirectsDiffBuilder):
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
-    app.add_config_value("rediraffe_redirects", "", None)
+    app.add_config_value("rediraffe_redirects", None, None)
     app.add_config_value("rediraffe_branch", "", None)
     app.add_config_value("rediraffe_template", None, None)
     app.add_config_value("rediraffe_auto_redirect_perc", 100, None)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -94,7 +94,8 @@ class TestExtHtml:
     @pytest.mark.sphinx("html", testroot="no_rediraffe_file")
     def test_no_rediraffe_file(self, app: Sphinx):
         app.build()
-        assert app.statuscode == 1
+        assert app.statuscode == 0
+        assert "rediraffe was not given redirects to process" in app._warning.getvalue()
 
     @pytest.mark.sphinx("html", testroot="redirect_from_deleted_folder")
     def test_redirect_from_deleted_folder(self, app: Sphinx, ensure_redirect):
@@ -277,7 +278,8 @@ class TestExtDirHtml:
     @pytest.mark.sphinx("dirhtml", testroot="no_rediraffe_file")
     def test_no_rediraffe_file(self, app: Sphinx):
         app.build()
-        assert app.statuscode == 1
+        assert app.statuscode == 0
+        assert "rediraffe was not given redirects to process" in app._warning.getvalue()
 
     @pytest.mark.sphinx("dirhtml", testroot="redirect_from_deleted_folder")
     def test_redirect_from_deleted_folder(self, app: Sphinx, ensure_redirect):


### PR DESCRIPTION
Otherwise sphinx logs warning: WARNING: The config value `rediraffe_redirects' has type `dict', defaults to `str'.