### PR TITLE
Include LICENSE.md in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setuptools.setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.6",
-    include_package_data=True
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,5 @@ setuptools.setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.6",
+    include_package_data=True
 )


### PR DESCRIPTION
Thanks for this tool!

While the MIT license doesn't require including the full license text, it's handy for downstreams... I'm looking to package this over on [conda-forge](https://github.com/conda-forge/staged-recipes/pull/13956) and it would be helpful if the license was included in the `sdist`. This PR just does the bit of boilerplate to make that happen.

The current plan is to just download the license separately, so no worries if this is not something you wish to do!

Thanks again!