### PR TITLE
feat: add option to strip '/index.html' from dest URLs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,13 @@ These values are placed in the :file:`conf.py` of your Sphinx project.
    The percentage as an integer representing the accuracy required before
    auto redirecting with the ``rediraffewritediff`` builder.
 
+.. confval:: rediraffe_dir_only
+   :type: :code-py:`bool`
+   :default: :code-py:`False`
+
+   Whether to include ``/index.html`` in destination URLs when using the ``dirhtml``
+   builder.
+
 Example Config
 ==============
 

--- a/sphinxext/rediraffe.py
+++ b/sphinxext/rediraffe.py
@@ -237,7 +237,11 @@ def build_redirects(app: Sphinx, exception: Exception | None) -> None:
                     src_redirect_from.parent / redirect_from_name / 'index.html'
                 )
             if redirect_to_name != 'index':
-                redirect_to = src_redirect_to.parent / redirect_to_name / 'index.html'
+                redirect_to = (
+                    src_redirect_to.parent / redirect_to_name
+                    if app.config.rediraffe_dir_only
+                    else src_redirect_to.parent / redirect_to_name / "index.html"
+                )
 
         # absolute paths into the build dir
         build_redirect_from = Path(app.outdir) / redirect_from
@@ -472,6 +476,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_config_value('rediraffe_branch', '', None)
     app.add_config_value('rediraffe_template', None, None)
     app.add_config_value('rediraffe_auto_redirect_perc', 100, None)
+    app.add_config_value('rediraffe_dir_only', False, 'env')
 
     app.add_builder(CheckRedirectsDiffBuilder)
     app.add_builder(WriteRedirectsDiffBuilder)

--- a/sphinxext/rediraffe.py
+++ b/sphinxext/rediraffe.py
@@ -240,7 +240,7 @@ def build_redirects(app: Sphinx, exception: Exception | None) -> None:
                 redirect_to = (
                     src_redirect_to.parent / redirect_to_name
                     if app.config.rediraffe_dir_only
-                    else src_redirect_to.parent / redirect_to_name / "index.html"
+                    else src_redirect_to.parent / redirect_to_name / 'index.html'
                 )
 
         # absolute paths into the build dir

--- a/tests/roots/ext/test-rediraffe_dir_only/conf.py
+++ b/tests/roots/ext/test-rediraffe_dir_only/conf.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+extensions = ['sphinxext.rediraffe']
+
+master_doc = 'index'
+exclude_patterns = ['_build']
+
+html_theme = 'basic'
+
+rediraffe_redirects = 'redirects.txt'
+rediraffe_dir_only = True

--- a/tests/roots/ext/test-rediraffe_dir_only/index.rst
+++ b/tests/roots/ext/test-rediraffe_dir_only/index.rst
@@ -1,0 +1,1 @@
+Index File

--- a/tests/roots/ext/test-rediraffe_dir_only/mypage.rst
+++ b/tests/roots/ext/test-rediraffe_dir_only/mypage.rst
@@ -1,0 +1,1 @@
+Destination File

--- a/tests/roots/ext/test-rediraffe_dir_only/redirects.txt
+++ b/tests/roots/ext/test-rediraffe_dir_only/redirects.txt
@@ -1,0 +1,1 @@
+another.rst mypage.rst

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -288,6 +288,12 @@ class TestExtDirHtml:
         assert app.statuscode == 0
         ensure_redirect('another/index.html', 'mydir/index.html')
 
+    @pytest.mark.sphinx('dirhtml', testroot='rediraffe_dir_only')
+    def test_rediraffe_dir_only(self, app: Sphinx, ensure_redirect):
+        app.build()
+        assert app.statuscode == 0
+        ensure_redirect('another/index.html', 'mypage/')
+
     @pytest.mark.sphinx('dirhtml', testroot='simple', freshenv=False)
     def test_simple_rebuild(self, app_params, make_app, ensure_redirect):
         args, kwargs = app_params


### PR DESCRIPTION
Add a `rediraffe_dir_only` config option that strips `/index.html` from destination URLs when building with `dirhtml`.

I'm open to any feedback on the design and implementation. Thanks in advance for your time!

Resolves https://github.com/sphinx-doc/sphinxext-rediraffe/issues/66